### PR TITLE
Do not log full_annotations during when downloading

### DIFF
--- a/darwin_fiftyone/darwin.py
+++ b/darwin_fiftyone/darwin.py
@@ -1640,7 +1640,6 @@ class DarwinAPI(foua.AnnotationAPI):
 
                 full_annotations.update({label_field: {label_type: sample_annotations}})
 
-        logging.info(f"Full annotations: {full_annotations}")
         return full_annotations
 
     def _generate_export(self, release_path, dataset):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="darwin-fiftyone",
-    version="1.1.22",
+    version="1.1.23",
     description="Integration between V7 Darwin and Voxel51",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Problem
While profiling memory consumption for [DAR-6551: BUG: Out-of-memory/storage issues when using load_annotations()](https://linear.app/v7labs/issue/DAR-6551/bug-out-of-memorystorage-issues-when-using-load-annotations), found out that pretty printing during logging creates a large memory overhead, customer runs into OOM errors.

# Solution
Dropping the logger.info call to reduce memory consumption.