### PR TITLE
Get requirements from egg-info at later build stages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ scikit-image>=0.19.0
 tqdm>=4.65.0
 requests>=2.28.0
 python-dotenv>=0.19.0
-boto3>=1.7.84
 
 # Development dependencies
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ scikit-image>=0.19.0
 tqdm>=4.65.0
 requests>=2.28.0
 python-dotenv>=0.19.0
+boto3>=1.38.10
 
 # Development dependencies
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ scikit-image>=0.19.0
 tqdm>=4.65.0
 requests>=2.28.0
 python-dotenv>=0.19.0
-boto3>=1.38.10
+boto3>=1.7.84
 
 # Development dependencies
 pytest>=7.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
+from pathlib import Path
 from setuptools import setup, find_packages
 
 # Read requirements while filtering out comments and development dependencies
-with open("requirements.txt") as f:
+requirements_path = "requirements.txt"
+if not Path(requirements_path).exists():
+    requirements_path = "darwin_fiftyone.egg-info/requires.txt"
+
+with open(requirements_path) as f:
     requirements = [
         line.strip()
         for line in f


### PR DESCRIPTION
`setup.py` gets sourced multiple times during `python -m build`, last time it's sourced from a temporary directory, where `requirements.txt` is not present, but `darwin_fiftyone.egg-info/requires.txt` is.