### PR TITLE
Filter out non-item-level properties during lookup

### DIFF
--- a/darwin_fiftyone/darwin.py
+++ b/darwin_fiftyone/darwin.py
@@ -1139,7 +1139,10 @@ class DarwinAPI(foua.AnnotationAPI):
         response = DarwinAPIWrapper.get(url, headers=headers)
         item_properties = json.loads(response.text)["properties"]
         for prop in item_properties:
-            if prop["name"] == item_property_name:
+            if (
+                prop["name"] == item_property_name
+                and not prop["annotation_class_id"]
+            ):
                 return [prop]
         return []
 

--- a/tests/test_darwin_fiftyone.py
+++ b/tests/test_darwin_fiftyone.py
@@ -441,6 +441,40 @@ def test_annotate_schema(setup_quickstart):
     )
 
 
+def test_schema_supports_different_level_attributes_with_same_name(setup_quickstart_empty):
+    dataset = setup_quickstart_empty
+
+    label_schema = {
+        "new_classifications": {
+            "type": "classifications",
+            "classes": [
+                {
+                    "classes": ["dog"],
+                    "attributes": {
+                        "same_attribute_name": {
+                            "type": "single_select",
+                            "values": ["inside_cart", "outside_cart"],
+                        },
+                    },
+                }
+            ],
+            "attributes": {
+                "same_attribute_name": {"type": "text"},
+            },
+        }
+    }
+
+    anno_key = "schema_with_same_name_attributes"
+    v7_dataset_slug = f"{dataset.name}-{anno_key}"
+    dataset.annotate(
+        anno_key,
+        label_schema=label_schema,
+        backend="darwin",
+        dataset_slug=v7_dataset_slug,
+        base_url="https://darwin.irl.v7labs.com/api/v2/teams",
+    )
+
+
 def test_load_schema():
     """See"""
 


### PR DESCRIPTION
Users encountered 422 errors during properties import. The property lookup code considered item-level properties with `annotation_class_id = null` to be the same as section-level properties with `annotation_class_id = 123` with the same name.