### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(requirements_path) as f:
 
 setup(
     name="darwin-fiftyone",
-    version="2.1.2",
+    version="2.2.0",
     description="Integration between V7 Darwin and Voxel51",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
- Bumps package version from `2.1.2` to `2.2.0` in `setup.py` in preparation for the v2.2.0 release

## Next steps
- After merging, create a GitHub release with tag `v2.2.0` to trigger the PyPI publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)