### PR TITLE
[Security] Bump Pillow to >=12.1.1 for CVE-2026-25990

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 fiftyone>=0.22.0
-darwin-py>=3.5.0
+darwin-py>=3.4.5
 pycocotools>=2.0.6
 
 # Data handling

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy>=1.21.0
 pandas>=1.3.0
 
 # Image processing
-Pillow>=9.0.0
+Pillow>=12.1.1
 opencv-python>=4.5.0
 scikit-image>=0.19.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 fiftyone>=0.22.0
-darwin-py>=1.0.8
+darwin-py>=3.5.0
 pycocotools>=2.0.6
 
 # Data handling

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
     author="Simon Edwardsson & Mark Cox-Smith",
     packages=find_packages(),
     url="https://github.com/v7labs/darwin_fiftyone",
+    python_requires=">=3.10",
     install_requires=requirements,
 )


### PR DESCRIPTION
## Summary
- Bumps Pillow from `>=9.0.0` to `>=12.1.1` to fix CVE-2026-25990 (out-of-bounds write in PSD handler, CVSS 8.1)
- Adds `python_requires=">=3.10"` (Pillow 12.x dropped 3.9, which is EOL since Oct 2025)
- Bumps darwin-py dependency to `>=3.4.5` (darwin-py 3.4.5 includes the Pillow fix, now live on PyPI)
- Updates CI Python from 3.9 to 3.10

## No breaking changes

**Pillow 9.x → 12.x:** No removed Pillow APIs are used in darwin-fiftyone.

**Python 3.9 → 3.10:** No Python 3.9-specific code in the codebase.

## Context
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-25990
- Snyk: https://security.snyk.io/vuln/SNYK-PYTHON-PILLOW-15265439
- Affects Pillow 10.3.0 through <12.1.1
- Flagged by Walmart SVS team via internal code audit
- Linear: https://linear.app/v7labs/issue/DAR-7556

## Test plan
- [x] CI passes with new Pillow version
- [x] Companion PR: v7labs/darwin-py#1134 (merged and released as v3.4.5)