### PR TITLE
Bump version to 2.2.1 for security patch release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(requirements_path) as f:
 
 setup(
     name="darwin-fiftyone",
-    version="2.2.0",
+    version="2.2.1",
     description="Integration between V7 Darwin and Voxel51",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
- Bumps version from 2.2.0 to 2.2.1 in `setup.py`
- Prepares release for the Pillow CVE-2026-25990 security fix merged in #24

## Context
This is a version bump only. The actual changes were merged in PR #24.
Once merged, a GitHub release will be created to trigger the PyPI publish workflow.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the package version in `setup.py`, with no code or dependency logic changes. Low risk aside from potential release/publishing coordination issues.
> 
> **Overview**
> Bumps the `darwin-fiftyone` package version from `2.2.0` to `2.2.1` in `setup.py` to cut a new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1354de94da4fc3c0daf4b5b0e4f0717854c2f7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->